### PR TITLE
mrc-2528 Complete ShinyRob prototype

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app" class="container">
-    <ChartSlot :step="1" tab-id="timeSeries"></ChartSlot>
+    <ChartSlot :step="1" tab-id="timeSeries" chart-height="500px"></ChartSlot>
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app" class="container">
-    <ChartSlot :step="1" tab-id="timeSeries" chart-height="500px"></ChartSlot>
+    <ChartSlot :step="1" tab-id="timeSeries" chart-height="700px"></ChartSlot>
   </div>
 </template>
 

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -40,7 +40,7 @@
             });
             function drawChart() {
                 const el = chart.value as unknown;
-                Plotly.react(el as HTMLElement, data.value.data, data.value.layout);
+                Plotly.react(el as HTMLElement, data.value.data, data.value.layout, data.value.config);
             }
             onMounted(() => {
                 drawChart();

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -40,7 +40,7 @@
             });
             function drawChart() {
                 const el = chart.value as unknown;
-                console.log("chart data: " + JSON.stringify(data.value.data))
+                console.log("chart input data: " + JSON.stringify(inputData.value))
                 Plotly.react(el as HTMLElement, data.value.data, data.value.layout);
             }
             onMounted(() => {

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-    <div ref="chart" style="width:800px; height:1000px;"></div>
+    <div ref="chart" style="width:100%; height:100%;"></div>
     </div>
 </template>
 

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -40,6 +40,7 @@
             });
             function drawChart() {
                 const el = chart.value as unknown;
+                console.log("chart data: " + JSON.stringify(data.value.data))
                 Plotly.react(el as HTMLElement, data.value.data, data.value.layout);
             }
             onMounted(() => {

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -40,7 +40,6 @@
             });
             function drawChart() {
                 const el = chart.value as unknown;
-                console.log("chart input data: " + JSON.stringify(inputData.value))
                 Plotly.react(el as HTMLElement, data.value.data, data.value.layout);
             }
             onMounted(() => {

--- a/src/components/ChartSlot.vue
+++ b/src/components/ChartSlot.vue
@@ -173,7 +173,7 @@
                     //Sort out layout issues around subplots - provide additional metadata to jsonata (rows and columns)
                     //and define scroll height
                     const layoutData = {} as any;
-                    let scrollHeight = "100*"
+                    let scrollHeight = "100%"
                     if (c.subplots) {
                         const numberOfPlots = [...new Set(chartData.data.data.map((row: any) => row[c.subplots!!.distinctColumn]))].length;
                         const rows = Math.ceil(numberOfPlots / c.subplots.columns);
@@ -229,13 +229,5 @@
 
     .annotation-text {
         font-weight: bold;
-    }
-
-    .ytick text{
-        fill: #777;
-    }
-
-    .xtick text{
-        fill: #777;
     }
 </style>

--- a/src/components/ChartSlot.vue
+++ b/src/components/ChartSlot.vue
@@ -35,7 +35,7 @@
                 </div>
             </div>
             <div class="col-9">
-                <chart :chart-metadata="chart.config" :chart-data="chart.chartData.data"></chart>
+                <chart :chart-metadata="chart.config" :chart-data="chart.chartData.data" :layout-data="chart.layoutData"></chart>
             </div>
         </div>
     </div>
@@ -63,6 +63,7 @@
 
     interface ChartValues {
         chartData: Record<string, any>
+        layoutData: Record<string, any>
         dataSourceValues: DataSourceValues[]
         datasets: DatasetConfig[]
         config: string
@@ -160,8 +161,27 @@
                     const chartConfig = chartSelections.chartConfigId ? c.chartConfig.find(c => c.id === chartSelections.chartConfigId)!
                                                                       : c.chartConfig[0];
 
+                    //Sort out layout issues around subplots - provide additional metadata to jsonata (rows and columns)
+                    //and define scroll height
+                    //TODO: Move to its own method?
+                    console.log("ChartData in ChartSlot: " + JSON.stringify(chartData))
+                    const layoutData = {} as any;
+                    if (c.subplots) {
+                        const numberOfPlots = [...new Set(chartData.data.data.map((row: any) => row[c.subplots!!.distinctColumn]))].length;
+
+                        console.log("number of plots: " + numberOfPlots)
+
+                        const rows = Math.ceil(numberOfPlots / c.subplots.columns);
+
+                        layoutData.subplots = {
+                            ...c.subplots,
+                            rows
+                        }
+                    }
+
                     return {
                         chartData,
+                        layoutData,
                         dataSourceValues,
                         datasets: c.datasets,
                         config: chartConfig.config,

--- a/src/components/ChartSlot.vue
+++ b/src/components/ChartSlot.vue
@@ -230,4 +230,16 @@
     .chart {
         width: 100%;
     }
+
+    .annotation-text {
+        font-weight: bold;
+    }
+
+    .ytick text{
+        fill: #777;
+    }
+
+    .xtick text{
+        fill: #777;
+    }
 </style>

--- a/src/components/ChartSlot.vue
+++ b/src/components/ChartSlot.vue
@@ -172,14 +172,10 @@
 
                     //Sort out layout issues around subplots - provide additional metadata to jsonata (rows and columns)
                     //and define scroll height
-                    console.log("ChartData in ChartSlot: " + JSON.stringify(chartData))
                     const layoutData = {} as any;
                     let scrollHeight = "100*"
                     if (c.subplots) {
                         const numberOfPlots = [...new Set(chartData.data.data.map((row: any) => row[c.subplots!!.distinctColumn]))].length;
-
-                        console.log("number of plots: " + numberOfPlots)
-
                         const rows = Math.ceil(numberOfPlots / c.subplots.columns);
 
                         layoutData.subplots = {

--- a/src/components/ChartSlot.vue
+++ b/src/components/ChartSlot.vue
@@ -35,7 +35,13 @@
                 </div>
             </div>
             <div class="col-9">
-                <chart :chart-metadata="chart.config" :chart-data="chart.chartData.data" :layout-data="chart.layoutData"></chart>
+                <div class="chart-container" :style="{height: chartHeight}">
+                    <chart class="chart"
+                           :chart-metadata="chart.config"
+                           :chart-data="chart.chartData.data"
+                           :layout-data="chart.layoutData"
+                           :style="{height: chart.scrollHeight}"></chart>
+                </div>
             </div>
         </div>
     </div>
@@ -67,6 +73,7 @@
         dataSourceValues: DataSourceValues[]
         datasets: DatasetConfig[]
         config: string
+        scrollHeight: string
         chartConfigOptions: {
             id: string,
             label: string,
@@ -85,7 +92,8 @@
 
     interface Props {
         step: number,
-        tabId: string
+        tabId: string,
+        chartHeight: string
     }
 
     interface Computed {
@@ -112,7 +120,8 @@
         name: "ChartSlot",
         props: {
             step: {type: Number},
-            tabId: {type: String}
+            tabId: {type: String},
+            chartHeight: {type: String}
         },
         components: {
             DataSource,
@@ -163,9 +172,9 @@
 
                     //Sort out layout issues around subplots - provide additional metadata to jsonata (rows and columns)
                     //and define scroll height
-                    //TODO: Move to its own method?
                     console.log("ChartData in ChartSlot: " + JSON.stringify(chartData))
                     const layoutData = {} as any;
+                    let scrollHeight = "100*"
                     if (c.subplots) {
                         const numberOfPlots = [...new Set(chartData.data.data.map((row: any) => row[c.subplots!!.distinctColumn]))].length;
 
@@ -177,6 +186,8 @@
                             ...c.subplots,
                             rows
                         }
+
+                        scrollHeight = `${c.subplots.heightPerRow * rows}px`;
                     }
 
                     return {
@@ -185,6 +196,7 @@
                         dataSourceValues,
                         datasets: c.datasets,
                         config: chartConfig.config,
+                        scrollHeight,
                         chartConfigOptions: c.chartConfig
                     }
                 });
@@ -209,3 +221,13 @@
     })
 </script>
 
+<style lang="scss">
+    .chart-container {
+        overflow-y: scroll;
+        width: 100%;
+    }
+
+    .chart {
+        width: 100%;
+    }
+</style>

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -88,7 +88,8 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                     },
                     subplots: {
                         columns: 3,
-                        distinctColumn: "area_name"
+                        distinctColumn: "area_name",
+                        heightPerRow: 100
                     },
                     chartConfig: [
                         {

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -95,14 +95,17 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                         {
                             id: "scatter",
                             label: "Scatter",
-                            config: `{
-                                "data":$map($distinct(data.area_name), function($v, $i) {
+                            config: `(
+                            $areaNames := $distinct(data.area_name);
+                            {
+                                "data":$map($areaNames, function($v, $i) {(
+                                    $areaData := data[area_name=$v];
                                     [
                                         {
                                             "name": $v,
                                             "showlegend": false,
-                                            "x": data[area_name=$v].year,
-                                            "y": data[area_name=$v].value,
+                                            "x": $areaData.year,
+                                            "y": $areaData.value,
                                             "xaxis": 'x' & ($i+1),
                                             "yaxis": 'y' & ($i+1),
                                             "type": "scatter",
@@ -114,15 +117,15 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                             "showlegend": false,
                                             "x": data[area_name=$v].year,
                                             "y": $map(data[area_name=$v].value, function($thv, $thi) {
-                                                   (($thi > 0) and $thv > (1.25 * (data[area_name=$v].value)[$thi-1])) 
+                                                   (($thi > 0) and $thv > (1.25 * ($areaData.value)[$thi-1])) 
                                                    or 
-                                                   (($thi < $count(data[area_name=$v].value)-1) and (data[area_name=$v].value)[$thi+1] > (1.25 * $thv)) 
+                                                   (($thi < $count($areaData.value)-1) and ($areaData.value)[$thi+1] > (1.25 * $thv)) 
                                                    or
-                                                   (($thi > 0) and $thv < (0.75 * (data[area_name=$v].value)[$thi-1])) 
+                                                   (($thi > 0) and $thv < (0.75 * ($areaData.value)[$thi-1])) 
                                                    or 
-                                                   (($thi < $count(data[area_name=$v].value)-1) and (data[area_name=$v].value)[$thi+1] < (0.75 * $thv))
+                                                   (($thi < $count($areaData.value)-1) and ($areaData.value)[$thi+1] < (0.75 * $thv))
                                                    ? $thv : null
-                                                }),
+                                             }),
                                             "xaxis": 'x' & ($i+1),
                                             "yaxis": 'y' & ($i+1),
                                             "type": "scatter",
@@ -132,11 +135,11 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                             "hoverinfo": "none"
                                         }
                                     ]    
-                                }).*,
+                                )}).*,
                                 "layout": $merge([
                                     {                            
                                         "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},
-                                        "annotations": $map($distinct(data.area_name), function($v, $i) {
+                                        "annotations": $map($areaNames, function($v, $i) {
                                             {
                                                 "text": $v & " (" & (data[area_name=$v].area_id)[0] & ")",
                                                 "textfont": {},
@@ -150,7 +153,7 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                             }
                                         })    
                                     },
-                                    [1..$count($distinct(data.area_name))]{
+                                    [1..$count($areaNames)]{
                                         "yaxis"&$: {
                                             "rangemode": "tozero",
                                             "zeroline": false,
@@ -165,7 +168,7 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                         } 
                                     }
                                 ])
-                            }`
+                            })`
                         },
                         {
                             id: "bar",

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -92,16 +92,35 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                             label: "Scatter",
                             config: `{
                                 "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 30}), function($v, $i) {
-                                    {
-                                        "name": $v,
-                                        "showlegend": false,
-                                        "x": data[area_name=$v].year,
-                                        "y": data[area_name=$v].value,
-                                        "xaxis": 'x' & ($i+1),
-                                        "yaxis": 'y' & ($i+1),
-                                        "type": "scatter"
-                                    }
-                                }),
+                                    [
+                                        {
+                                            "name": $v,
+                                            "showlegend": false,
+                                            "x": data[area_name=$v].year,
+                                            "y": data[area_name=$v].value,
+                                            "xaxis": 'x' & ($i+1),
+                                            "yaxis": 'y' & ($i+1),
+                                            "type": "scatter",
+                                            "line": {
+                                                "color": "rgb(51, 51, 51)"
+                                            }
+                                        },
+                                        {
+                                            "name": $v,
+                                            "showlegend": false,
+                                            "x": data[area_name=$v].year,
+                                            "y": $map(data[area_name=$v].value, function($thv, $thi) {
+                                                    $thv > 20000 or ($i > 0 and data[area_name=$v].value[i-1] > 20000)? $thv : null
+                                                }),
+                                            "xaxis": 'x' & ($i+1),
+                                            "yaxis": 'y' & ($i+1),
+                                            "type": "scatter",
+                                            "line": {
+                                                "color": "rgb(255, 51, 51)"
+                                            }
+                                        }
+                                    ]    
+                                }).*,
                                 "layout": {                            
                                     "grid": {"columns": 3, "rows": 10, "pattern": 'independent'}
                                 }
@@ -119,7 +138,10 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                         "y": data[area_name=$v].value,
                                         "xaxis": 'x' & ($i+1),
                                         "yaxis": 'y' & ($i+1),
-                                        "type": "bar"
+                                        "type": "bar",
+                                        "marker": {
+                                            "color": "rgb(51, 51, 51)"
+                                        }
                                     }
                                 }),
                                 "layout": {                            

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -133,22 +133,38 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                         }
                                     ]    
                                 }).*,
-                                "layout": {                            
-                                    "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},
-                                    "annotations": $map($distinct(data.area_name), function($v, $i) {
-                                        {
-                                          "text": $v & " (" & (data[area_name=$v].area_id)[0] & ")",
-                                          "textfont": {},
-                                          "showarrow": false,
-                                          "x": 0.5,
-                                          "xanchor": "middle",
-                                          "xref": "x" & ($i+1) & " domain",
-                                          "y": 1,
-                                          "yanchor": "middle",
-                                          "yref": "y" & ($i+1) & " domain"
-                                        }
-                                    })    
-                                }
+                                "layout": $merge([
+                                    {                            
+                                        "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},
+                                        "annotations": $map($distinct(data.area_name), function($v, $i) {
+                                            {
+                                                "text": $v & " (" & (data[area_name=$v].area_id)[0] & ")",
+                                                "textfont": {},
+                                                "showarrow": false,
+                                                "x": 0.5,
+                                                "xanchor": "middle",
+                                                "xref": "x" & ($i+1) & " domain",
+                                                "y": 1,
+                                                "yanchor": "middle",
+                                                "yref": "y" & ($i+1) & " domain"
+                                            }
+                                        })    
+                                    },
+                                    [1..$count($distinct(data.area_name))]{
+                                        "yaxis"&$: {
+                                            "rangemode": "tozero",
+                                            "zeroline": false,
+                                            "tickfont": {
+                                                "color": "grey"
+                                            }
+                                        },
+                                        "xaxis"&$: {
+                                            "tickfont": {
+                                                "color": "grey"
+                                            }
+                                        } 
+                                    }
+                                ])
                             }`
                         },
                         {

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -110,7 +110,10 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                             "showlegend": false,
                                             "x": data[area_name=$v].year,
                                             "y": $map(data[area_name=$v].value, function($thv, $thi) {
-                                                    $thv > 20000 or ($i > 0 and data[area_name=$v].value[i-1] > 20000)? $thv : null
+                                                   (($thi > 0) and $thv > (1.25 * (data[area_name=$v].value)[$thi-1])) 
+                                                   or 
+                                                   (($thi < $count(data[area_name=$v].value)-1) and (data[area_name=$v].value)[$thi+1] > (1.25 * $thv)) 
+                                                   ? $thv : null
                                                 }),
                                             "xaxis": 'x' & ($i+1),
                                             "yaxis": 'y' & ($i+1),

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -134,7 +134,20 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                     ]    
                                 }).*,
                                 "layout": {                            
-                                    "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'}
+                                    "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},
+                                    "annotations": $map($distinct(data.area_name), function($v, $i) {
+                                        {
+                                          "text": $v & " (" & (data[area_name=$v].area_id)[0] & ")",
+                                          "textfont": {},
+                                          "showarrow": false,
+                                          "x": 0.5,
+                                          "xanchor": "middle",
+                                          "xref": "x" & ($i+1) & " domain",
+                                          "y": 1,
+                                          "yanchor": "middle",
+                                          "yref": "y" & ($i+1) & " domain"
+                                        }
+                                    })    
                                 }
                             }`
                         },

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -105,14 +105,17 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                                 "color": "rgb(51, 51, 51)"
                                             }
                                         },
-                                        {
-                                            "name": $v,
+                                        {                                        
                                             "showlegend": false,
                                             "x": data[area_name=$v].year,
                                             "y": $map(data[area_name=$v].value, function($thv, $thi) {
                                                    (($thi > 0) and $thv > (1.25 * (data[area_name=$v].value)[$thi-1])) 
                                                    or 
                                                    (($thi < $count(data[area_name=$v].value)-1) and (data[area_name=$v].value)[$thi+1] > (1.25 * $thv)) 
+                                                   or
+                                                   (($thi > 0) and $thv < (0.75 * (data[area_name=$v].value)[$thi-1])) 
+                                                   or 
+                                                   (($thi < $count(data[area_name=$v].value)-1) and (data[area_name=$v].value)[$thi+1] < (0.75 * $thv))
                                                    ? $thv : null
                                                 }),
                                             "xaxis": 'x' & ($i+1),
@@ -120,7 +123,8 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                             "type": "scatter",
                                             "line": {
                                                 "color": "rgb(255, 51, 51)"
-                                            }
+                                            },
+                                            "hoverinfo": "none"
                                         }
                                     ]    
                                 }).*,

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -91,14 +91,14 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                             id: "scatter",
                             label: "Scatter",
                             config: `{
-                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 31}), function($v, $i) {
+                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 30}), function($v, $i) {
                                     {
                                         "name": $v,
                                         "showlegend": false,
                                         "x": data[area_name=$v].year,
                                         "y": data[area_name=$v].value,
-                                        "xaxis": 'x' & $i,
-                                        "yaxis": 'y' & $i,
+                                        "xaxis": 'x' & ($i+1),
+                                        "yaxis": 'y' & ($i+1),
                                         "type": "scatter"
                                     }
                                 }),
@@ -111,14 +111,14 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                             id: "bar",
                             label: "Bar",
                             config: `{
-                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 31}), function($v, $i) {
+                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 30}), function($v, $i) {
                                     {
                                         "name": $v,
                                         "showlegend": false,
                                         "x": data[area_name=$v].year,
                                         "y": data[area_name=$v].value,
-                                        "xaxis": 'x' & $i,
-                                        "yaxis": 'y' & $i,
+                                        "xaxis": 'x' & ($i+1),
+                                        "yaxis": 'y' & ($i+1),
                                         "type": "bar"
                                     }
                                 }),

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -20,7 +20,7 @@
 // There may be multiple jsonata chart configurations per chart (which will expand to full Plotly chart configs when
 // data is available). When there are more than one, the user will be able to choose which to display from a drop-down.
 
-import {FilterOption, GenericChartsConfig} from "@/types";
+import {GenericChartsConfig} from "@/types";
 
 export const genericChartsSampleConfig : GenericChartsConfig = {
     slots: [
@@ -86,12 +86,16 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                             }
                         ]
                     },
+                    subplots: {
+                        columns: 3,
+                        distinctColumn: "area_name"
+                    },
                     chartConfig: [
                         {
                             id: "scatter",
                             label: "Scatter",
                             config: `{
-                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 30}), function($v, $i) {
+                                "data":$map($distinct(data.area_name), function($v, $i) {
                                     [
                                         {
                                             "name": $v,
@@ -129,7 +133,7 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                     ]    
                                 }).*,
                                 "layout": {                            
-                                    "grid": {"columns": 3, "rows": 10, "pattern": 'independent'}
+                                    "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'}
                                 }
                             }`
                         },
@@ -137,7 +141,7 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                             id: "bar",
                             label: "Bar",
                             config: `{
-                                "data":$map($filter($distinct(data.area_name), function($v, $i) {$i < 30}), function($v, $i) {
+                                "data":$map($distinct(data.area_name), function($v, $i) {
                                     {
                                         "name": $v,
                                         "showlegend": false,
@@ -152,7 +156,7 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                     }
                                 }),
                                 "layout": {                            
-                                    "grid": {"columns": 3, "rows": 10, "pattern": 'independent'}
+                                    "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'}
                                 }
                             }`
                         }

--- a/src/config/genericChartsConfig.ts
+++ b/src/config/genericChartsConfig.ts
@@ -136,9 +136,10 @@ export const genericChartsSampleConfig : GenericChartsConfig = {
                                         }
                                     ]    
                                 )}).*,
+                                "config": {"responsive": true},
                                 "layout": $merge([
                                     {                            
-                                        "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},
+                                        "grid": {"columns": subplots.columns, "rows": subplots.rows, "pattern": 'independent'},                                     
                                         "annotations": $map($areaNames, function($v, $i) {
                                             {
                                                 "text": $v & " (" & (data[area_name=$v].area_id)[0] & ")",

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,8 @@ export interface ChartConfig
     },
     subplots?: {
         columns: number,
-        distinctColumn: string
+        distinctColumn: string,
+        heightPerRow: number
     },
     chartConfig: {
        id: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,10 @@ export interface ChartConfig
     dataSelectors: {
         dataSources: DataSourceConfig[]
     },
+    subplots?: {
+        columns: number,
+        distinctColumn: string
+    },
     chartConfig: {
        id: string,
        label: string,


### PR DESCRIPTION
This branch fixes most of the issues remaining in the prototype at the end of the last sprint. I'd suggest that the fact that this now basically works as required means that we can indeed treat the ShinyRob chart as a 'generic chart' as implemented here, rather than needing to create a custom component with special knowledge of this particular chart. The only 'special' added here is to deal with variable numbers of subplots, indicated by optional chart metadata. 

Changes made:
- fixes bug where first two subplots shared axes (need to get axis names rights, and also don't show more plots than you have defined in rows and columns settings)
- Colours line segments exceeding threshold value drop or rise in red, all other segments are black. (Not implemnted for barchart, as barchart does not need to be included in first version.) We are not including user editing of threshold for first version either - this is hard-coded to 0.25 increase or decrease.
- Implements scroll of subplots area (this seemed to be preferred to paging by the Naomi group), and no longer limits number of plots to 30. A special 'subplots' config element can now  be included, and if so the `ChartSlot`component uses it to calculate the number of subplot rows which will be required. This is passed to the Chart jsonata as additional metadata, along with the config-provided columns value, and the ChartSlot also uses it to calculate the required scroll height to contain all the rows. The ChartSlot also has a prop for `chartHeight` the height of the chart component on the page (container of the scrolled area). It's currently showing 3 plots per row as that seemed comfortable for this layout, but we can change that to 4 as in ShinyRob if preferred. 
- Area name and id are displayed as annotations on the plots, using the domains of subplot axes as reference points
- Adds some visual tweaks to the axes e.g. tick text in grey, and range goes to 0 for y axes
- Improved jsonata performance by using variables for values which were repeatedly calculated - load time was reduced from ~12s to 4.5s for me. In the real app, it would probably be worth showing a spinner while re-rendering.

This is not yet using the realistic sample data, but I think this should have minimal impact structurally - it will affect the filters somewhat e.g. will have basic area level filter rather than full Area filter (hence I haven't addressed the Area filter bugs). See ticket for discussion of other changes I'm proposing to leave until integration with HINT.

It occurs to me now that perhaps we should make `ChartSlot` (probably renamed!) a standalone component, incorporating the functionality of the `genericCharts` module, so that it does its own filtering etc. This feels easier now that we know the HINT datasets for all the new charts are likely to mean fetching non-standard datasets from a configured url (something we could include in the component) but it would also be possible if data was coming from the store e.g. by supporting specifying a standard data source by a name which maps to a Root getter.  

Making the component standalone in this way will make it easier to use in other applications including an application for quickly testing chart configs.

I haven't yet updated the KB article which references this prototype, but I will when this gets merged.

I haven't added all  changes into the bar plot as only the scatter plot is required for initial version.  

We'll probably remove most of the Plotly gubbins at the top of the chart (Zoom etc) but could leave e.g. download plot as image